### PR TITLE
Update commons-validator to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>commons-validator</groupId>
 			<artifactId>commons-validator</artifactId>
-			<version>1.4.0</version>
+			<version>1.5.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
It aims to [support new TLDs](https://issues.apache.org/jira/browse/VALIDATOR-348).